### PR TITLE
refactor: JWT 인증 흐름 개선 및 @AuthenticationPrincipal 적용

### DIFF
--- a/src/main/java/com/boardmate/config/SwaggerConfig.java
+++ b/src/main/java/com/boardmate/config/SwaggerConfig.java
@@ -36,7 +36,15 @@ public class SwaggerConfig {
     private Info apiInfo() {
         return new Info()
                 .title("BoardMate API")
-                .description("보드게임 커뮤니티 플랫폼 API 문서")
+                .description("보드게임 커뮤니티 플랫폼 API 문서"
+                        + "<br><br>" +
+                        "/api/auth/sync-from-nextauth : NextAuth가 처음 로그인 후 유저를 동기화하기 위해 부르는 API입니다.(JWT 포함 반환)"
+                        + "<br><br>" +
+                        "해당 API는 메일 주소 기반으로 사용자를 식별하며, 이미 가입된 사용자라면 기존 정보를 반환합니다. 신규 사용자라면 DB에 저장 후 정보를 반환합니다."
+                        + "<br><br>" +
+                        "모든 API는 JWT 인증이 필요합니다(테스트, 시스템 제외)"
+                        + "<br><br>" +
+                        "Swagger UI 우측 상단의 'Authorize' 버튼을 클릭하여 발급받은 JWT 토큰을 입력해야 합니다.")
                 .version("1.0.0");
     }
 

--- a/src/main/java/com/boardmate/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/boardmate/config/jwt/JwtAuthenticationFilter.java
@@ -30,8 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             HttpServletRequest request,
             HttpServletResponse response,
-            FilterChain filterChain
-    ) throws ServletException, IOException {
+            FilterChain filterChain) throws ServletException, IOException {
 
         String header = request.getHeader("Authorization");
 
@@ -39,11 +38,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = header.substring(7);
 
             try {
-                // ✅ NextAuth가 서명한 JWT 검증
+                // JWT 검증
                 Jws<Claims> jws = jwtTokenProvider.parseToken(token);
                 Claims claims = jws.getPayload();
 
-                // ✅ NextAuth jwt 콜백에서 token.userId = 백엔드 userId 로 넣어놨다고 가정
+                // 토큰 클레임에 userId가 들어있다고 가정
                 Object userIdClaim = claims.get("userId");
                 Long userId = null;
 
@@ -55,11 +54,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     userId = Long.parseLong(s);
                 }
 
-                // (옵션) 예전 방식처럼 sub에 userId가 들어오는 것도 함께 지원하고 싶다면:
                 if (userId == null && claims.getSubject() != null) {
                     try {
                         userId = Long.parseLong(claims.getSubject());
-                    } catch (NumberFormatException ignored) {}
+                    } catch (NumberFormatException ignored) {
+                    }
                 }
 
                 if (userId != null) {
@@ -74,10 +73,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         var authorities = List.of(new SimpleGrantedAuthority(roleName));
 
                         var authentication = new UsernamePasswordAuthenticationToken(
-                                user,      // principal
-                                null,      // credentials
-                                authorities
-                        );
+                                user, // principal
+                                null, // credentials
+                                authorities);
 
                         SecurityContextHolder.getContext().setAuthentication(authentication);
                     }

--- a/src/main/java/com/boardmate/controller/AuthController.java
+++ b/src/main/java/com/boardmate/controller/AuthController.java
@@ -1,13 +1,13 @@
 package com.boardmate.controller;
 
-import com.boardmate.config.jwt.JwtTokenProvider;
+import com.boardmate.domain.user.User;
 import com.boardmate.dto.auth.CompleteSignupRequest;
 import com.boardmate.dto.auth.SocialLoginRequest;
 import com.boardmate.dto.auth.SocialLoginResponse;
 import com.boardmate.service.UserService;
-import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +20,15 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final JwtTokenProvider jwtTokenProvider;
     private final UserService userService;
 
-    @Operation(summary = "NextAuth 유저 동기화", description = "NextAuth 서버에서 소셜 로그인 후 유저 정보를 Spring Boot DB에 동기화합니다. (내부 API)")
+    @Operation(summary = "NextAuth 유저 동기화", description = "NextAuth 서버에서 소셜 로그인 후 유저 정보를 Spring Boot DB에 동기화합니다. (내부 API)"
+            + "<br><br>" +
+            "email을 기준으로 사용자를 식별하며, 이미 가입된 사용자라면 기존 정보를 반환합니다. 신규 사용자라면 DB에 저장 후 정보를 반환합니다. "
+            + "<br><br>" +
+            "이미 가입된 사용자인지 여부도 함께 반환됩니다.(alreadyRegistered)"
+            + "<br><br>" +
+            "/api/auth/sync-from-nextauth는 동기화 API이며, /api/auth/complete-signup는 추가 정보 입력 후 회원가입 완료 API입니다.")
     @ApiResponse(responseCode = "200", description = "동기화 성공")
     @PostMapping("/sync-from-nextauth")
     public ResponseEntity<SocialLoginResponse> syncFromNextAuth(
@@ -32,17 +37,18 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "회원가입 완료", description = "소셜 로그인 후 추가 정보(닉네임, 생년월일)를 입력하여 회원가입을 완료합니다. JWT 토큰이 필요합니다.")
+    @Operation(summary = "회원가입 완료", description = "소셜 로그인 후 추가 정보(닉네임, 생년월일)를 입력하여 회원가입을 완료합니다. JWT 토큰이 필요합니다."
+            + "<br><br>" +
+            "/api/auth/sync-from-nextauth는 동기화 API이며, /api/auth/complete-signup는 추가 정보 입력 후 회원가입 완료 API입니다.")
     @ApiResponse(responseCode = "200", description = "회원가입 완료 성공")
     @PostMapping("/complete-signup")
     public ResponseEntity<Void> completeSignup(
-            @Parameter(description = "JWT 토큰", example = "Bearer eyJhbGciOiJIUzI1NiJ9...") @RequestHeader("Authorization") String authHeader,
+            @Parameter(hidden = true) @AuthenticationPrincipal User user,
             @RequestBody CompleteSignupRequest request) {
-        String token = authHeader.replace("Bearer ", "");
-        Claims claims = jwtTokenProvider.parseToken(token).getPayload();
-        Long userId = Long.parseLong(claims.getSubject());
-
-        userService.completeSignup(userId, request);
+        if (user == null) {
+            return ResponseEntity.status(401).build();
+        }
+        userService.completeSignup(user.getId(), request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/boardmate/controller/TestController.java
+++ b/src/main/java/com/boardmate/controller/TestController.java
@@ -1,8 +1,6 @@
 package com.boardmate.controller;
 
 import com.boardmate.domain.user.User;
-import com.boardmate.dto.auth.SocialLoginRequest;
-import com.boardmate.dto.auth.SocialLoginResponse;
 import com.boardmate.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -20,15 +18,6 @@ import java.util.List;
 public class TestController {
 
     private final UserService userService;
-
-    @Operation(summary = "테스트 로그인", description = "Swagger 테스트를 위한 소셜 로그인 API입니다. 백엔드 자체 JWT를 발급합니다.")
-    @ApiResponse(responseCode = "200", description = "로그인 성공, JWT 토큰 발급")
-    @PostMapping("/login")
-    public ResponseEntity<SocialLoginResponse> testLogin(
-            @RequestBody SocialLoginRequest request) {
-        SocialLoginResponse response = userService.socialLogin(request);
-        return ResponseEntity.ok(response);
-    }
 
     @Operation(summary = "전체 사용자 목록 조회", description = "개발/테스트용 API입니다. users 테이블의 모든 사용자 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")

--- a/src/main/java/com/boardmate/domain/user/User.java
+++ b/src/main/java/com/boardmate/domain/user/User.java
@@ -10,33 +10,34 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
 
     @Column(nullable = false, length = 255, unique = true)
-    private String email;          // 카카오/구글 이메일
+    private String email; // 카카오/구글 이메일
 
     @Column(length = 255)
-    private String nickname;       // 회원 정보 입력 화면에서 받기
+    private String nickname; // 회원 정보 입력 화면에서 받기
 
     @Column(name = "social_id", length = 500, nullable = false)
-    private String socialId;       // provider가 주는 고유 ID
+    private String socialId; // provider가 주는 고유 ID
 
     @Column(name = "provider", length = 50, nullable = false)
-    private String provider;       // "kakao", "google"
+    private String provider; // "kakao", "google"
 
     @Column(length = 50)
-    private String gender;         // "MALE", "FEMALE" 등
+    private String gender; // "MALE", "FEMALE" 등
 
     @Column(length = 255)
-    private String region;         // "서울특별시 강남구" 같은 문자열
+    private String region; // "서울특별시 강남구" 같은 문자열
 
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
     @Column(length = 50)
-    private String role;           // "USER", "ADMIN"
+    private String role; // "USER", "ADMIN"
 
     private Boolean isActive;
 
@@ -45,8 +46,8 @@ public class User {
 
     @Builder
     public User(String email, String nickname, String socialId, String provider,
-                String gender, String region, String profileImageUrl,
-                String role, Boolean isActive) {
+            String gender, String region, String profileImageUrl,
+            String role, Boolean isActive) {
         this.email = email;
         this.nickname = nickname;
         this.socialId = socialId;
@@ -62,8 +63,10 @@ public class User {
     public void onCreate() {
         this.createdAt = LocalDateTime.now();
         this.updatedAt = this.createdAt;
-        if (this.role == null) this.role = "USER";
-        if (this.isActive == null) this.isActive = true;
+        if (this.role == null)
+            this.role = "USER";
+        if (this.isActive == null)
+            this.isActive = true;
     }
 
     @PreUpdate
@@ -83,5 +86,13 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/boardmate/dto/auth/SocialLoginRequest.java
+++ b/src/main/java/com/boardmate/dto/auth/SocialLoginRequest.java
@@ -1,12 +1,23 @@
 package com.boardmate.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 @Data
+@Schema(description = "소셜 로그인 요청 DTO (NextAuth → Spring Boot)")
 public class SocialLoginRequest {
-    private String provider;         // "kakao" | "google"
-    private String socialId;         // providerAccountId
+    @Schema(description = "소셜 로그인 제공자", example = "kakao")
+    private String provider;
+
+    @Schema(description = "소셜 계정 고유 ID (providerAccountId)", example = "1234567890")
+    private String socialId;
+
+    @Schema(description = "사용자 이메일", example = "user@example.com")
     private String email;
-    private String nickname;         // 소셜 닉네임
+
+    @Schema(description = "소셜 닉네임", example = "보드러버")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://k.kakaocdn.net/dn/...jpg")
     private String profileImageUrl;
 }

--- a/src/main/java/com/boardmate/dto/auth/SocialLoginResponse.java
+++ b/src/main/java/com/boardmate/dto/auth/SocialLoginResponse.java
@@ -1,20 +1,38 @@
 package com.boardmate.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+@Schema(description = "소셜 로그인 응답 DTO (Spring Boot → NextAuth)")
 @Data
 @AllArgsConstructor
 public class SocialLoginResponse {
 
+    @Schema(description = "DB 사용자 ID", example = "1")
     private Long userId;
-    private String email;
-    private String nickname;
-    private String role;
-    private boolean profileCompleted;  // 추가 정보 입력 여부
 
-    // 기존 로그인 로직을 위해 필드는 그대로 두고 사용할지 말지만 선택.
+    @Schema(description = "이메일", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "닉네임", example = "보드러버")
+    private String nickname;
+
+    @Schema(description = "권한", example = "USER")
+    private String role;
+
+    @Schema(description = "추가 정보 입력 여부", example = "false")
+    private boolean profileCompleted;
+
+    @Schema(description = "(구버전) 액세스 토큰", example = "null")
     private String accessToken;
+
+    @Schema(description = "(구버전) 리프레시 토큰", example = "null")
     private String refreshToken;
+
+    @Schema(description = "(구버전) 액세스 토큰 만료 시각", example = "0")
     private long accessTokenExpiresAt;
+
+    @Schema(description = "이미 등록된 사용자 여부", example = "true")
+    private boolean alreadyRegistered;
 }

--- a/src/main/java/com/boardmate/repository/UserRepository.java
+++ b/src/main/java/com/boardmate/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByProviderAndSocialId(String provider, String socialId);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/boardmate/service/UserService.java
+++ b/src/main/java/com/boardmate/service/UserService.java
@@ -26,28 +26,26 @@ public class UserService {
      */
     @Transactional
     public SocialLoginResponse socialLogin(SocialLoginRequest req) {
-        Optional<User> optionalUser = userRepository.findByProviderAndSocialId(req.getProvider(), req.getSocialId());
 
-        User user = optionalUser
-                .map(u -> {
-                    // 이메일 등 최신 정보로 업데이트
-                    if (req.getEmail() != null) {
-                        u.setEmail(req.getEmail());
-                    }
-                    return u;
-                })
-                .orElseGet(() -> userRepository.save(
-                        User.builder()
-                                .email(req.getEmail())
-                                .nickname(req.getNickname())
-                                .socialId(req.getSocialId())
-                                .provider(req.getProvider())
-                                .profileImageUrl(req.getProfileImageUrl())
-                                .role("USER")
-                                .isActive(true)
-                                .build()));
+        Optional<User> optionalUser = userRepository.findByEmail(req.getEmail());
+        boolean alreadyRegistered = optionalUser.isPresent();
 
-        // ⬇ 이 부분은 "백엔드 JWT" 발급 (NextAuth 구조에서는 안 써도 됨)
+        User user;
+        if (alreadyRegistered) {
+            user = optionalUser.get();
+        } else {
+            user = User.builder()
+                    .email(req.getEmail())
+                    .nickname(req.getNickname())
+                    .socialId(req.getSocialId())
+                    .provider(req.getProvider())
+                    .profileImageUrl(req.getProfileImageUrl())
+                    .role("USER")
+                    .isActive(true)
+                    .build();
+            userRepository.save(user);
+        }
+
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
         long expiresAt = System.currentTimeMillis() + 1000L * 60 * 60; // 1시간
@@ -60,7 +58,8 @@ public class UserService {
                 user.isProfileCompleted(),
                 accessToken,
                 refreshToken,
-                expiresAt);
+                expiresAt,
+                alreadyRegistered);
     }
 
     /**
@@ -71,13 +70,7 @@ public class UserService {
      */
     @Transactional
     public SocialLoginResponse syncUserFromNextAuth(SocialLoginRequest req) {
-        SocialLoginResponse response = socialLogin(req);
-
-        response.setAccessToken(null);
-        response.setRefreshToken(null);
-        response.setAccessTokenExpiresAt(0L);
-
-        return response;
+        return socialLogin(req);
     }
 
     @Transactional


### PR DESCRIPTION
- complete-signup 엔드포인트에서 수동 헤더 파싱 제거
- @AuthenticationPrincipal User 사용으로 코드 간결화
- Swagger 문서에 JWT 인증 가이드 추가
- 사용자 조회 기준을 email 기반으로 통일
- alreadyRegistered 플래그 추가로 기존/신규 사용자 구분
- 테스트 엔드포인트 정리 및 DTO Swagger 스키마 개선