### PR TITLE
feat(auth): HttpOnly 쿠키로 refresh 토큰 관리 전환 + 응답 스키마 정리

### DIFF
--- a/src/main/java/com/boardmate/config/SecurityConfig.java
+++ b/src/main/java/com/boardmate/config/SecurityConfig.java
@@ -22,6 +22,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    // Refresh Token Cookie 설정 상수
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    public static final int REFRESH_TOKEN_COOKIE_MAX_AGE = 14 * 24 * 60 * 60; // 14일 (초 단위)
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Value("${cors.allowed-origin}")
@@ -38,6 +42,7 @@ public class SecurityConfig {
                         // NextAuth가 처음 로그인 후 유저를 동기화하기 위해 부르는 API는 공개
                         .requestMatchers(
                                 "/api/auth/sync-from-nextauth",
+                                "/api/auth/refresh", // 토큰 재발급 (인증 불필요)
                                 "/api/test/**", // 테스트 API
                                 "/db-check",
                                 "/mongo-check",

--- a/src/main/java/com/boardmate/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/boardmate/config/jwt/JwtAuthenticationFilter.java
@@ -2,7 +2,9 @@ package com.boardmate.config.jwt;
 
 import com.boardmate.domain.user.User;
 import com.boardmate.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -16,7 +18,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -31,6 +35,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        // /api/test/** 경로는 토큰 검증 건너뛰기 (만료되어도 접근 가능)
+        if (requestURI.startsWith("/api/test/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
 
         String header = request.getHeader("Authorization");
 
@@ -81,12 +93,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     }
                 }
 
-            } catch (Exception ex) {
-                // 토큰이 유효하지 않으면 인증 정보 비우고 넘어감 → 나중에 401
+            } catch (ExpiredJwtException ex) {
+                // 액세스 토큰 만료 → 401 (재인증 가능)
                 SecurityContextHolder.clearContext();
+                sendErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED,
+                        "TOKEN_EXPIRED", "Access token has expired. Please refresh your token.");
+                return;
+            } catch (Exception ex) {
+                // 기타 토큰 오류 (변조, 형식 오류 등) → 403 (재인증해도 접근 불가)
+                SecurityContextHolder.clearContext();
+                sendErrorResponse(response, HttpServletResponse.SC_FORBIDDEN,
+                        "INVALID_TOKEN", "Invalid or malformed token.");
+                return;
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, int status, String error, String message)
+            throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("error", error);
+        errorResponse.put("message", message);
+        errorResponse.put("timestamp", System.currentTimeMillis());
+
+        ObjectMapper mapper = new ObjectMapper();
+        response.getWriter().write(mapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/boardmate/controller/AuthController.java
+++ b/src/main/java/com/boardmate/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.boardmate.domain.user.User;
 import com.boardmate.dto.auth.CompleteSignupRequest;
 import com.boardmate.dto.auth.SocialLoginRequest;
 import com.boardmate.dto.auth.SocialLoginResponse;
+import com.boardmate.dto.auth.TokenRefreshResponse;
 import com.boardmate.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,6 +15,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+import static com.boardmate.config.SecurityConfig.REFRESH_TOKEN_COOKIE_NAME;
+import static com.boardmate.config.SecurityConfig.REFRESH_TOKEN_COOKIE_MAX_AGE;
+
 @Tag(name = "인증(Auth)", description = "로그인 및 회원가입 관련 API")
 @RestController
 @RequestMapping("/api/auth")
@@ -22,33 +29,166 @@ public class AuthController {
 
     private final UserService userService;
 
-    @Operation(summary = "NextAuth 유저 동기화", description = "NextAuth 서버에서 소셜 로그인 후 유저 정보를 Spring Boot DB에 동기화합니다. (내부 API)"
-            + "<br><br>" +
-            "email을 기준으로 사용자를 식별하며, 이미 가입된 사용자라면 기존 정보를 반환합니다. 신규 사용자라면 DB에 저장 후 정보를 반환합니다. "
-            + "<br><br>" +
-            "이미 가입된 사용자인지 여부도 함께 반환됩니다.(alreadyRegistered)"
-            + "<br><br>" +
-            "/api/auth/sync-from-nextauth는 동기화 API이며, /api/auth/complete-signup는 추가 정보 입력 후 회원가입 완료 API입니다.")
+    @Operation(summary = "NextAuth 유저 동기화", description = "NextAuth 서버에서 소셜 로그인 후 유저 정보를 Spring Boot DB에 동기화합니다."
+            + "<br><br>"
+            + "<b>[ 동작 방식 ]</b>"
+            + "<br>• email을 기준으로 사용자 식별"
+            + "<br>• 신규 사용자: DB에 저장 후 JWT 토큰 발급"
+            + "<br>• 기존 사용자: 기존 정보 반환 및 새 토큰 발급"
+            + "<br>• alreadyRegistered 필드로 신규/기존 구분 가능"
+            + "<br><br>"
+            + "<b>[ 응답 ]</b>"
+            + "<br>• Body: userId, accessToken (refreshToken은 Body에 포함되지 않음)"
+            + "<br>• Cookie: refreshToken (HttpOnly, Secure, 14일)"
+            + "<br><br>"
+            + "<b>[ 참고 ]</b>"
+            + "<br>• Next.js/NextAuth 서버는 Body의 refreshToken을 사용하지 않음"
+            + "<br>• 프론트엔드(브라우저)는 HttpOnly 쿠키로 자동 관리"
+            + "<br>• /api/auth/complete-signup: 추가 정보 입력 후 회원가입 완료")
     @ApiResponse(responseCode = "200", description = "동기화 성공")
     @PostMapping("/sync-from-nextauth")
     public ResponseEntity<SocialLoginResponse> syncFromNextAuth(
-            @RequestBody SocialLoginRequest request) {
-        SocialLoginResponse response = userService.syncUserFromNextAuth(request);
-        return ResponseEntity.ok(response);
+            @RequestBody SocialLoginRequest request,
+            HttpServletResponse response) {
+        SocialLoginResponse loginResponse = userService.syncUserFromNextAuth(request);
+
+        // Refresh Token을 HttpOnly 쿠키로 설정
+        if (loginResponse.getRefreshToken() != null) {
+            Cookie refreshTokenCookie = createRefreshTokenCookie(loginResponse.getRefreshToken());
+            response.addCookie(refreshTokenCookie);
+
+            // 응답 Body에서는 refreshToken 제거 (보안상 쿠키로만 전달)
+            loginResponse.setRefreshToken(null);
+        }
+
+        return ResponseEntity.ok(loginResponse);
     }
 
-    @Operation(summary = "회원가입 완료", description = "소셜 로그인 후 추가 정보(닉네임, 생년월일)를 입력하여 회원가입을 완료합니다. JWT 토큰이 필요합니다."
-            + "<br><br>" +
-            "/api/auth/sync-from-nextauth는 동기화 API이며, /api/auth/complete-signup는 추가 정보 입력 후 회원가입 완료 API입니다.")
+    @Operation(summary = "회원가입 완료", description = "소셜 로그인 후 추가 정보를 입력하여 회원가입을 완료합니다."
+            + "<br><br>"
+            + "<b>[ 요구사항 ]</b>"
+            + "<br>• JWT Access Token 필요 (Authorization 헤더)"
+            + "<br>• 닉네임, 성별, 지역, 약관 동의 정보 필수"
+            + "<br><br>"
+            + "<b>[ 동작 ]</b>"
+            + "<br>• 사용자 프로필 정보 업데이트"
+            + "<br>• 약관 동의 정보 저장 (서버 시간 기준)"
+            + "<br>• Refresh Token 생성 및 HttpOnly 쿠키로 발급"
+            + "<br><br>"
+            + "<b>[ 플로우 ]</b>"
+            + "<br>1. /api/auth/sync-from-nextauth (소셜 로그인 동기화)"
+            + "<br>2. /api/auth/complete-signup (추가 정보 입력) ← 현재 API")
     @ApiResponse(responseCode = "200", description = "회원가입 완료 성공")
     @PostMapping("/complete-signup")
     public ResponseEntity<Void> completeSignup(
             @Parameter(hidden = true) @AuthenticationPrincipal User user,
-            @RequestBody CompleteSignupRequest request) {
+            @RequestBody CompleteSignupRequest request,
+            HttpServletResponse response) {
         if (user == null) {
             return ResponseEntity.status(401).build();
         }
-        userService.completeSignup(user.getId(), request);
+        String refreshToken = userService.completeSignup(user.getId(), request);
+
+        // Refresh Token을 HttpOnly 쿠키로 설정
+        Cookie refreshTokenCookie = createRefreshTokenCookie(refreshToken);
+        response.addCookie(refreshTokenCookie);
+
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "토큰 재발급", description = "⚠️ Swagger에서는 HttpOnly 쿠키를 지원하지 않으므로 Postman을 사용하세요."
+            + "<br><br>" +
+            "<b>[ 동작 방식 ]</b>"
+            + "<br>• 리프레시 토큰은 HttpOnly 쿠키로 자동 전송됩니다 (Request Body 없음)"
+            + "<br>• 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다 (Refresh Token Rotation)"
+            + "<br>• 보안을 위해 매 재발급마다 리프레시 토큰도 갱신됩니다"
+            + "<br><br>" +
+            "<b>[ 토큰 유효 기간 ]</b>"
+            + "<br>• Access Token: 1시간"
+            + "<br>• Refresh Token: 14일"
+            + "<br><br>" +
+            "<b>[ 에러 응답 ]</b>"
+            + "<br>• REFRESH_TOKEN_NOT_FOUND (401): 쿠키에 리프레시 토큰이 없음"
+            + "<br>• INVALID_REFRESH_TOKEN (401): 유효하지 않거나 만료된 리프레시 토큰"
+            + "<br><br>" +
+            "<b>[ Postman 테스트 방법 ]</b>"
+            + "<br>1. POST /api/auth/sync-from-nextauth 호출 → 쿠키 자동 저장"
+            + "<br>   Body (raw JSON):"
+            + "<br>   {"
+            + "<br>     \"provider\": \"kakao\","
+            + "<br>     \"socialId\": \"1234567890\","
+            + "<br>     \"email\": \"user@example.com\","
+            + "<br>     \"nickname\": \"보드러버\","
+            + "<br>     \"profileImageUrl\": \"https://k.kakaocdn.net/dn/...jpg\""
+            + "<br>   }"
+            + "<br><br>2. POST /api/auth/refresh 호출 → 새 토큰 받음"
+            + "<br>   Headers: 없음"
+            + "<br>   Body: 없음 (쿠키 자동 전송)"
+            + "<br>   Settings: Send cookies 활성화")
+    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공")
+    @ApiResponse(responseCode = "401", description = "리프레시 토큰이 없거나 유효하지 않음")
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenRefreshResponse> refreshToken(
+            @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken,
+            HttpServletResponse response) {
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.status(401)
+                    .body(TokenRefreshResponse.error("REFRESH_TOKEN_NOT_FOUND"));
+        }
+
+        try {
+            TokenRefreshResponse tokenResponse = userService.refreshToken(refreshToken);
+
+            // 새 Refresh Token을 쿠키로 설정 (토큰 로테이션)
+            Cookie newRefreshTokenCookie = createRefreshTokenCookie(tokenResponse.getRefreshToken());
+            response.addCookie(newRefreshTokenCookie);
+
+            // 응답에서는 refreshToken 제거 (쿠키로만 전달)
+            tokenResponse.setRefreshToken(null);
+
+            return ResponseEntity.ok(tokenResponse);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(401)
+                    .body(TokenRefreshResponse.error("INVALID_REFRESH_TOKEN"));
+        }
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃 시 리프레시 토큰 쿠키를 삭제합니다."
+            + "<br><br>"
+            + "<b>[ 동작 ]</b>"
+            + "<br>• refreshToken 쿠키 삭제 (MaxAge=0)"
+            + "<br>• 클라이언트에서 accessToken도 제거 권장"
+            + "<br><br>"
+            + "<b>[ 참고 ]</b>"
+            + "<br>• DB에 저장된 refreshToken은 자동으로 무효화되지 않음"
+            + "<br>• 완전한 무효화가 필요하면 서버 측 로직 추가 필요")
+    @ApiResponse(responseCode = "200", description = "로그아웃 성공")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(HttpServletResponse response) {
+        // 쿠키 삭제 (MaxAge=0)
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Strict");
+
+        response.addCookie(cookie);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * HttpOnly Secure 쿠키 생성 헬퍼 메서드
+     */
+    private Cookie createRefreshTokenCookie(String refreshToken) {
+        Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        cookie.setHttpOnly(true); // JavaScript 접근 차단
+        cookie.setSecure(true); // HTTPS에서만 전송
+        cookie.setPath("/"); // 전체 경로에서 사용
+        cookie.setMaxAge(REFRESH_TOKEN_COOKIE_MAX_AGE); // 14일
+        cookie.setAttribute("SameSite", "Strict"); // CSRF 기본 방어
+
+        return cookie;
     }
 }

--- a/src/main/java/com/boardmate/controller/TestController.java
+++ b/src/main/java/com/boardmate/controller/TestController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "테스트", description = "개발/테스트용 API (운영 환경에서는 비활성화)")
+@Tag(name = "테스트", description = "개발/테스트용 API (운영 환경에서는 비활성화) - 테스트는 auth만료되어도 접근 가능")
 @RestController
 @RequestMapping("/api/test")
 @RequiredArgsConstructor
@@ -25,5 +25,25 @@ public class TestController {
     public ResponseEntity<List<User>> getAllUsers() {
         List<User> users = userService.getAllUsers();
         return ResponseEntity.ok(users);
+    }
+
+    @Operation(summary = "ID별 사용자 조회", description = "개발/테스트용 API입니다. 특정 ID의 사용자 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "사용자 없음")
+    @GetMapping("/userbyid/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable Long id) {
+        return userService.getUserById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @Operation(summary = "이메일별 사용자 조회", description = "개발/테스트용 API입니다. 특정 이메일의 사용자 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    @ApiResponse(responseCode = "404", description = "사용자 없음")
+    @GetMapping("/userbyemail")
+    public ResponseEntity<User> getUserByEmail(@RequestParam String email) {
+        return userService.getUserByEmail(email)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/com/boardmate/domain/user/User.java
+++ b/src/main/java/com/boardmate/domain/user/User.java
@@ -50,6 +50,10 @@ public class User {
     private Boolean consentLocation;
     private LocalDateTime consentAgreedAt;
 
+    // 토큰 재발급용 리프레시 토큰 저장
+    @Column(length = 500)
+    private String refreshToken;
+
     @Builder
     public User(String email, String nickname, String socialId, String provider,
             String gender, String region, String profileImageUrl,
@@ -107,5 +111,13 @@ public class User {
 
     public void setNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void clearRefreshToken() {
+        this.refreshToken = null;
     }
 }

--- a/src/main/java/com/boardmate/dto/auth/TokenRefreshRequest.java
+++ b/src/main/java/com/boardmate/dto/auth/TokenRefreshRequest.java
@@ -1,0 +1,12 @@
+package com.boardmate.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "토큰 재발급 요청")
+public class TokenRefreshRequest {
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+}

--- a/src/main/java/com/boardmate/dto/auth/TokenRefreshResponse.java
+++ b/src/main/java/com/boardmate/dto/auth/TokenRefreshResponse.java
@@ -1,0 +1,40 @@
+package com.boardmate.dto.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 재발급 응답")
+public class TokenRefreshResponse {
+
+    @Schema(description = "오류 코드 (REFRESH_TOKEN_NOT_FOUND, INVALID_REFRESH_TOKEN 등)")
+    private String errorCode;
+
+    @Schema(description = "새로 발급된 액세스 토큰")
+    private String accessToken;
+
+    @Schema(description = "새로 발급된 리프레시 토큰 (HttpOnly 쿠키로 전달되므로 응답에서는 null)")
+    private String refreshToken;
+
+    @Schema(description = "액세스 토큰 만료 시각")
+    private Long accessTokenExpiresAt;
+
+    // 성공 응답용 생성자
+    public TokenRefreshResponse(String accessToken, String refreshToken, Long accessTokenExpiresAt) {
+        this.errorCode = null;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.accessTokenExpiresAt = accessTokenExpiresAt;
+    }
+
+    // 에러 응답용 정적 팩토리 메서드
+    public static TokenRefreshResponse error(String errorCode) {
+        TokenRefreshResponse response = new TokenRefreshResponse();
+        response.setErrorCode(errorCode);
+        return response;
+    }
+}

--- a/src/main/java/com/boardmate/service/UserService.java
+++ b/src/main/java/com/boardmate/service/UserService.java
@@ -5,6 +5,7 @@ import com.boardmate.domain.user.User;
 import com.boardmate.dto.auth.CompleteSignupRequest;
 import com.boardmate.dto.auth.SocialLoginRequest;
 import com.boardmate.dto.auth.SocialLoginResponse;
+import com.boardmate.dto.auth.TokenRefreshResponse;
 import com.boardmate.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,6 +51,10 @@ public class UserService {
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
         long expiresAt = System.currentTimeMillis() + 1000L * 60 * 60; // 1시간
 
+        // 리프레시 토큰 DB에 저장
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
         return new SocialLoginResponse(
                 user.getId(),
                 user.getEmail(),
@@ -74,7 +79,7 @@ public class UserService {
     }
 
     @Transactional
-    public void completeSignup(Long userId, CompleteSignupRequest req) {
+    public String completeSignup(Long userId, CompleteSignupRequest req) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
@@ -85,6 +90,13 @@ public class UserService {
             // 서버 시간으로 동의 시각 저장
             user.updateConsent(c.getService(), c.getPrivacy(), c.getLocation());
         }
+
+        // 리프레시 토큰 생성 및 DB 저장
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        return refreshToken;
     }
 
     /**
@@ -93,5 +105,54 @@ public class UserService {
     @Transactional(readOnly = true)
     public List<User> getAllUsers() {
         return userRepository.findAll();
+    }
+
+    /**
+     * 테스트/개발용: 아이디별 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    /**
+     * 테스트/개발용: 메일별 사용자 조회
+     */
+    @Transactional(readOnly = true)
+    public Optional<User> getUserByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    /**
+     * 리프레시 토큰으로 액세스 토큰 재발급 (+ 리프레시 토큰 rotation)
+     */
+    @Transactional
+    public TokenRefreshResponse refreshToken(String refreshToken) {
+        // 1) 리프레시 토큰 파싱 및 유효성 검증
+        Long userId;
+        try {
+            userId = Long.parseLong(jwtTokenProvider.parseToken(refreshToken).getPayload().getSubject());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid or expired refresh token");
+        }
+
+        // 2) 사용자 조회 및 DB에 저장된 리프레시 토큰과 비교
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        if (user.getRefreshToken() == null || !user.getRefreshToken().equals(refreshToken)) {
+            throw new IllegalArgumentException("Refresh token does not match or has been revoked");
+        }
+
+        // 3) 새 액세스 토큰 및 새 리프레시 토큰 발급 (rotation)
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        long expiresAt = System.currentTimeMillis() + 1000L * 60 * 60; // 1시간
+
+        // 4) 새 리프레시 토큰 DB에 저장
+        user.updateRefreshToken(newRefreshToken);
+        userRepository.save(user);
+
+        return new TokenRefreshResponse(newAccessToken, newRefreshToken, expiresAt);
     }
 }


### PR DESCRIPTION
SecurityConfig: refreshToken 쿠키 상수 추가
AuthController:
- sync-from-nextauth/complete-signup에서 refreshToken을 HttpOnly Secure SameSite=Strict 쿠키로 발급
- refresh에서 쿠키 기반 재발급 및 로테이션 적용
- logout 엔드포인트 추가(쿠키 삭제)
- Swagger 문서 개선 및 Postman 가이드 추가
- sync-from-nextauth 응답 Body에서 refreshToken 제거 UserService: completeSignup이 refreshToken 생성/저장 후 반환 TokenRefreshResponse: errorCode 필드 & 에러 팩토리 추가, 에러 응답 매핑 수정 Note: dev 환경 HTTP에서는 Secure 쿠키 미전송 가능

BREAKING CHANGE: /api/auth/sync-from-nextauth 응답에서 refreshToken 필드 제거(쿠키로만 전달).